### PR TITLE
feat(api): guards globales de auth y roles [B1-08]

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -9,6 +9,8 @@ import { HealthModule } from './health/health.module';
 import { PrismaModule } from './prisma/prisma.module';
 import { AuthModule } from './modules/auth/auth.module';
 import { HttpExceptionFilter } from './common/filters/http-exception.filter';
+import { JwtAuthGuard } from './common/guards/jwt-auth.guard';
+import { RolesGuard } from './common/guards/roles.guard';
 import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 import { TransformInterceptor } from './common/interceptors/transform.interceptor';
 
@@ -60,7 +62,13 @@ import { TransformInterceptor } from './common/interceptors/transform.intercepto
     { provide: APP_FILTER, useClass: HttpExceptionFilter },
     { provide: APP_INTERCEPTOR, useClass: LoggingInterceptor },
     { provide: APP_INTERCEPTOR, useClass: TransformInterceptor },
+    // Orden de los guards globales: throttle primero, luego autenticación
+    // (puebla request.user) y por último autorización por rol. Todo queda
+    // autenticado por defecto; usar @Public() para abrir una ruta y @Roles()
+    // para restringir por rol.
     { provide: APP_GUARD, useClass: ThrottlerGuard },
+    { provide: APP_GUARD, useClass: JwtAuthGuard },
+    { provide: APP_GUARD, useClass: RolesGuard },
   ],
 })
 export class AppModule {}

--- a/apps/api/src/common/decorators/public.decorator.spec.ts
+++ b/apps/api/src/common/decorators/public.decorator.spec.ts
@@ -1,0 +1,15 @@
+import { Reflector } from '@nestjs/core';
+import { Public, IS_PUBLIC_KEY } from './public.decorator';
+
+describe('Public decorator', () => {
+  it('setea metadata isPublic=true en el handler', () => {
+    class Dummy {
+      @Public()
+      handler() {}
+    }
+    // Real Reflector: verificamos que @Public escribe metadata que NestJS lee.
+    const reflector = new Reflector();
+    const value = reflector.get<boolean>(IS_PUBLIC_KEY, Dummy.prototype.handler);
+    expect(value).toBe(true);
+  });
+});

--- a/apps/api/src/common/decorators/public.decorator.ts
+++ b/apps/api/src/common/decorators/public.decorator.ts
@@ -1,0 +1,11 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+
+/**
+ * Marca una ruta como pública: el `JwtAuthGuard` global la deja pasar sin
+ * requerir un access token. Usar en endpoints de auth (login, refresh) y en
+ * sondas de salud. Todo lo que NO lleve `@Public()` queda autenticado por
+ * defecto (guard global en `AppModule`).
+ */
+export const Public = (): MethodDecorator & ClassDecorator => SetMetadata(IS_PUBLIC_KEY, true);

--- a/apps/api/src/common/guards/jwt-auth.guard.spec.ts
+++ b/apps/api/src/common/guards/jwt-auth.guard.spec.ts
@@ -1,0 +1,51 @@
+import { ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
+import { JwtAuthGuard } from './jwt-auth.guard';
+
+function makeCtx(): ExecutionContext {
+  const handler = () => undefined;
+  const Cls = function Cls() {};
+  return {
+    getHandler: () => handler,
+    getClass: () => Cls,
+  } as unknown as ExecutionContext;
+}
+
+describe('JwtAuthGuard', () => {
+  function makeGuard(isPublic: unknown) {
+    const reflector = {
+      getAllAndOverride: jest.fn().mockReturnValue(isPublic),
+    } as unknown as Reflector;
+    return { guard: new JwtAuthGuard(reflector), reflector };
+  }
+
+  it('deja pasar sin autenticar si la ruta es @Public', () => {
+    const { guard } = makeGuard(true);
+    expect(guard.canActivate(makeCtx())).toBe(true);
+  });
+
+  it('delega en la autenticación JWT (super) si la ruta no es pública', () => {
+    const { guard } = makeGuard(false);
+    // Spy en el canActivate del padre (AuthGuard('jwt')) para no ejecutar passport real.
+    const parentProto = Object.getPrototypeOf(Object.getPrototypeOf(guard));
+    const superSpy = jest.spyOn(parentProto, 'canActivate').mockReturnValue('super-llamado');
+    const ctx = makeCtx();
+
+    const result = guard.canActivate(ctx);
+
+    expect(superSpy).toHaveBeenCalledWith(ctx);
+    expect(result).toBe('super-llamado');
+    superSpy.mockRestore();
+  });
+
+  it('consulta IS_PUBLIC_KEY sobre handler y class', () => {
+    const { guard, reflector } = makeGuard(true);
+    const ctx = makeCtx();
+    guard.canActivate(ctx);
+    expect(reflector.getAllAndOverride).toHaveBeenCalledWith(IS_PUBLIC_KEY, [
+      ctx.getHandler(),
+      ctx.getClass(),
+    ]);
+  });
+});

--- a/apps/api/src/common/guards/jwt-auth.guard.ts
+++ b/apps/api/src/common/guards/jwt-auth.guard.ts
@@ -1,8 +1,29 @@
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
 
 /**
- * Valida el access token JWT y puebla `request.user` con el `RequestUser`
- * devuelto por `JwtStrategy.validate`. Usar junto a `RolesGuard`:
- * `@UseGuards(JwtAuthGuard, RolesGuard)`.
+ * Guard de autenticación global: valida el access token JWT y puebla
+ * `request.user` con el `RequestUser` de `JwtStrategy.validate`. Está
+ * registrado como `APP_GUARD` en `AppModule`, así que **toda** ruta queda
+ * autenticada por defecto. Las rutas marcadas con `@Public()` se dejan pasar
+ * sin token (login, refresh, health, etc.).
  */
-export class JwtAuthGuard extends AuthGuard('jwt') {}
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  constructor(private readonly reflector: Reflector) {
+    super();
+  }
+
+  canActivate(context: ExecutionContext) {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) {
+      return true;
+    }
+    return super.canActivate(context);
+  }
+}

--- a/apps/api/src/common/index.ts
+++ b/apps/api/src/common/index.ts
@@ -1,4 +1,5 @@
 export * from './decorators/current-user.decorator';
+export * from './decorators/public.decorator';
 export * from './decorators/roles.decorator';
 export * from './filters/http-exception.filter';
 export * from './guards/jwt-auth.guard';

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -1,8 +1,12 @@
 import { Controller, Get, VERSION_NEUTRAL } from '@nestjs/common';
 import { HealthCheck, HealthCheckService } from '@nestjs/terminus';
 import { SkipThrottle } from '@nestjs/throttler';
+import { Public } from '../common/decorators/public.decorator';
 import { PrismaHealthIndicator } from './prisma.health';
 
+// Sonda de salud pública: la consume el load balancer sin credenciales, por eso
+// queda fuera del guard de auth global (@Public) y del throttle (@SkipThrottle).
+@Public()
 @Controller({ path: 'health', version: VERSION_NEUTRAL })
 // Health probes must never be throttled — a 429 reads as an unhealthy instance to a
 // load balancer. The endpoint is read-only and touches no user data; a high-rate

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -1,10 +1,9 @@
-import { Body, Controller, HttpCode, Post, UseGuards } from '@nestjs/common';
+import { Body, Controller, HttpCode, Post } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
 import { ROLES } from '@gestion-academica/shared';
 import { CurrentUser } from '../../common/decorators/current-user.decorator';
+import { Public } from '../../common/decorators/public.decorator';
 import { Roles } from '../../common/decorators/roles.decorator';
-import { JwtAuthGuard } from '../../common/guards/jwt-auth.guard';
-import { RolesGuard } from '../../common/guards/roles.guard';
 import type { RequestUser } from '../../common/types/request-user';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
@@ -16,13 +15,15 @@ import { RegisterDto } from './dto/register.dto';
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
+  // Único endpoint protegido del módulo: crea usuarios. El guard global de auth
+  // puebla request.user y @Roles restringe a SUPER_ADMIN/ADMIN.
   @Post('register')
-  @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(ROLES.SUPER_ADMIN, ROLES.ADMIN)
   register(@Body() dto: RegisterDto, @CurrentUser() currentUser: RequestUser) {
     return this.authService.register(dto, currentUser);
   }
 
+  @Public()
   @Post('login')
   @HttpCode(200)
   @Throttle({ default: { limit: 10, ttl: 60_000 } })
@@ -30,12 +31,14 @@ export class AuthController {
     return this.authService.login(dto);
   }
 
+  @Public()
   @Post('refresh')
   @HttpCode(200)
   refresh(@Body() dto: RefreshDto) {
     return this.authService.refresh(dto);
   }
 
+  @Public()
   @Post('logout')
   @HttpCode(204)
   logout(@Body() dto: LogoutDto) {

--- a/apps/api/test/app.e2e-spec.ts
+++ b/apps/api/test/app.e2e-spec.ts
@@ -50,9 +50,13 @@ describe('App (e2e)', () => {
     expect(res.headers['access-control-allow-credentials']).toBe('true');
   });
 
-  it('GET /api/v1/__ok → 200 con cuerpo {data:"ok"}', async () => {
+  it('GET /api/v1/__ok → 200 con cuerpo {data:"ok"} (ruta @Public)', async () => {
     const res = await request(app.getHttpServer()).get('/api/v1/__ok').expect(200);
     expect(res.body).toEqual({ data: 'ok' });
+  });
+
+  it('GET /api/v1/__protected sin token → 401 (auth global por defecto)', async () => {
+    await request(app.getHttpServer()).get('/api/v1/__protected').expect(401);
   });
 
   it('GET /api/v1/__nope → 404 con formato de error uniforme', async () => {

--- a/apps/api/test/test-fixtures.module.ts
+++ b/apps/api/test/test-fixtures.module.ts
@@ -1,5 +1,6 @@
 import { Body, Controller, Get, Module, Post } from '@nestjs/common';
 import { IsEmail, IsNotEmpty } from 'class-validator';
+import { Public } from '../src/common/decorators/public.decorator';
 
 class ValidatePayload {
   @IsEmail()
@@ -9,6 +10,9 @@ class ValidatePayload {
   name!: string;
 }
 
+// Fixtures de bootstrap (no de auth): quedan públicas para no depender de un
+// token en los e2e que prueban validación/transform/filtros del pipeline HTTP.
+@Public()
 @Controller()
 export class TestFixturesController {
   @Get('__ok')
@@ -22,7 +26,17 @@ export class TestFixturesController {
   }
 }
 
+// Sin @Public ni @Roles: sirve para verificar que el guard de auth global deja
+// toda ruta autenticada por defecto (debe responder 401 sin token).
+@Controller()
+export class ProtectedFixturesController {
+  @Get('__protected')
+  protected() {
+    return 'secreto';
+  }
+}
+
 @Module({
-  controllers: [TestFixturesController],
+  controllers: [TestFixturesController, ProtectedFixturesController],
 })
 export class TestFixturesModule {}

--- a/docs/AUTHORIZATION.md
+++ b/docs/AUTHORIZATION.md
@@ -1,0 +1,75 @@
+# Autorización — Roles y permisos
+
+Modelo de autenticación y autorización del backend. Define quién puede acceder a
+qué y cómo se aplica en el código.
+
+> Issue de referencia: `[B1-08]` (#8). Implementado sobre el módulo de auth del
+> `[B1-06]` (#6).
+
+## Modelo: autenticado por defecto
+
+El backend registra **dos guards globales** (`APP_GUARD` en `app.module.ts`),
+que corren después del `ThrottlerGuard`:
+
+1. **`JwtAuthGuard`** — valida el access token JWT y puebla `request.user` con el
+   `RequestUser` (`{ id, email, role }`). Si falta el token o es inválido → `401`.
+2. **`RolesGuard`** — si el handler/clase declara `@Roles(...)`, exige que
+   `request.user.role` esté en la lista; si no → `403`. Sin `@Roles`, deja pasar.
+
+**Consecuencia:** toda ruta queda autenticada por defecto. No hay que agregar
+`@UseGuards` por endpoint.
+
+### Abrir o restringir rutas
+
+| Decorador          | Efecto                                                 | Ejemplo                                        |
+| ------------------ | ------------------------------------------------------ | ---------------------------------------------- |
+| `@Public()`        | La ruta se sirve **sin token** (salta `JwtAuthGuard`). | `login`, `refresh`, `logout`, `GET /health`    |
+| `@Roles(rol, ...)` | Solo esos roles acceden; el resto recibe `403`.        | `POST /auth/register` → `SUPER_ADMIN`, `ADMIN` |
+| _(ninguno)_        | Autenticado, cualquier rol.                            | CRUDs de lectura general                       |
+
+`@Public()` y `@Roles()` se pueden poner a nivel de método o de clase
+(`getAllAndOverride` resuelve método sobre clase).
+
+El usuario inactivo (`isActive = false`) se rechaza en `JwtStrategy.validate`
+(→ `401`), aunque el token sea válido.
+
+## Roles del sistema
+
+Fuente de verdad: `ROLES` en `@gestion-academica/shared`.
+
+| Rol             | Nivel de acceso                                                   |
+| --------------- | ----------------------------------------------------------------- |
+| `SUPER_ADMIN`   | Configuración técnica y mantenimiento. Puede crear cualquier rol. |
+| `ADMIN`         | Gestión completa del colegio. **No** puede crear `SUPER_ADMIN`.   |
+| `DIRECTOR`      | Lectura global, dashboards.                                       |
+| `PROFESOR_JEFE` | Su curso (jefatura) + funciones de profesor.                      |
+| `PROFESOR`      | Sus asignaturas/cursos asignados.                                 |
+| `ESTUDIANTE`    | Su propia información.                                            |
+| `APODERADO`     | Información de sus pupilos.                                       |
+
+### Sub-regla de creación de usuarios
+
+En `POST /auth/register` (ver `AuthService.register`): un `ADMIN` no puede crear
+un `SUPER_ADMIN` (→ `403`, antes de tocar la BD). Un `SUPER_ADMIN` puede crear
+cualquier rol.
+
+## Matriz de permisos por operación
+
+`@Roles(...)` cubre la autorización **a nivel de ruta** (qué rol entra al
+endpoint). La granularidad **a nivel de recurso** ("este profesor solo ve _sus_
+cursos", "este apoderado solo ve a _sus_ pupilos") se resuelve dentro de cada
+servicio cuando exista el CRUD correspondiente — no es responsabilidad del guard.
+
+| Operación                         | Roles permitidos (ruta)                 | Filtro a nivel de recurso         |
+| --------------------------------- | --------------------------------------- | --------------------------------- |
+| Crear usuarios (`/auth/register`) | `SUPER_ADMIN`, `ADMIN`                  | —                                 |
+| CRUD usuarios / personas          | `SUPER_ADMIN`, `ADMIN`                  | —                                 |
+| CRUD cursos / asignaturas         | `SUPER_ADMIN`, `ADMIN`                  | —                                 |
+| Lectura de dashboards globales    | `SUPER_ADMIN`, `ADMIN`, `DIRECTOR`      | —                                 |
+| Gestión de notas/evaluaciones     | `PROFESOR`, `PROFESOR_JEFE` (+ `ADMIN`) | Solo cursos/asignaturas asignados |
+| Ver notas/asistencia propias      | `ESTUDIANTE`                            | Solo el propio `studentId`        |
+| Ver información de pupilos        | `APODERADO`                             | Solo alumnos vinculados           |
+
+> Esta tabla es el contrato de referencia. Cada issue de CRUD (Bloque 2 en
+> adelante) debe aplicar el `@Roles(...)` correspondiente y el filtro de recurso
+> en su servicio, y actualizar esta tabla si introduce una operación nueva.


### PR DESCRIPTION
## Resumen

Completa el sistema de autorización por roles (#8) sobre el módulo de auth del PR #86. Pasa de protección **opt-in por ruta** (`@UseGuards`) a **autenticado por defecto** mediante guards globales.

- `JwtAuthGuard` y `RolesGuard` registrados como `APP_GUARD` globales en `AppModule` (orden: throttle → auth → roles).
- Nuevo decorador `@Public()` (`IS_PUBLIC_KEY`): el `JwtAuthGuard` global salta la autenticación en rutas marcadas. Aplicado a `login`, `refresh`, `logout` y `GET /health`.
- `JwtAuthGuard` ahora inyecta `Reflector` y consulta `IS_PUBLIC_KEY` (método sobre clase) antes de delegar en passport.
- `POST /auth/register` deja de usar `@UseGuards(...)` explícito; queda protegido por el guard global + `@Roles(SUPER_ADMIN, ADMIN)`.
- Usuario inactivo sigue rechazado en `JwtStrategy.validate` (→ 401).
- Doc `docs/AUTHORIZATION.md`: modelo de auth global, uso de `@Public`/`@Roles`, los 7 roles y la matriz de permisos por operación (contrato para los CRUD de Bloque 2+).

## Qué cubre del issue #8

- [x] `RolesGuard` valida roles del usuario autenticado (ya venía de #86; ahora global)
- [x] `@Roles()` integrado con el guard
- [x] Validación de usuario activo (`JwtStrategy.validate`)
- [x] Rutas base protegidas: health público, **todo lo demás autenticado por defecto**
- [x] Definición de permisos por rol → `docs/AUTHORIZATION.md`
- [x] Tests unitarios (RolesGuard ya existía; +`@Public`/`JwtAuthGuard`)

## Test Plan

- [x] `lint` → limpio
- [x] `format:check` → limpio
- [x] `build` → limpio
- [x] `test` → **76/76** unit (+4: `public.decorator`, `jwt-auth.guard`)
- [x] `test:e2e` → **14/14** (+1: `GET /api/v1/__protected` sin token → 401, valida el contrato "autenticado por defecto")

## Notas

- Se agregó una ruta-fixture protegida (`__protected`, sin `@Public`/`@Roles`) en los e2e para fijar el contrato: cualquier ruta nueva queda autenticada salvo que se marque `@Public()`.
- El filtro **a nivel de recurso** (profesor solo ve sus cursos, apoderado solo sus pupilos) se implementa en cada servicio de CRUD; el guard solo cubre el nivel de ruta. Documentado en `AUTHORIZATION.md`.

Closes #8